### PR TITLE
Use new Task-oriented method of handling sign-in

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -33,7 +33,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     implementation 'com.android.support:design:28.0.0'
-    compile 'com.google.android.gms:play-services-auth:16.0.1'
+    implementation 'com.google.android.gms:play-services-auth:16.0.1'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'android.arch.persistence.room:runtime:1.1.1'
     annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
     implementation "android.arch.lifecycle:extensions:1.1.1"
-    implementation 'com.readystatesoftware.sqliteasset:sqliteassethelper:+'
+    implementation 'com.readystatesoftware.sqliteasset:sqliteassethelper:2.0.1'
     testImplementation "org.robolectric:robolectric:4.0.1"
 
 

--- a/app/src/main/java/edu/cwru/students/cwrumapper/SignInActivity.java
+++ b/app/src/main/java/edu/cwru/students/cwrumapper/SignInActivity.java
@@ -151,10 +151,15 @@ public class SignInActivity extends AppCompatActivity implements GoogleApiClient
 
             case R.id.guest_sign_in_button:
                 Log.v(TAG, "Guest Sign-in tapped");
+                // Alert user that guest sign-in not fully implemented
+                Snackbar.make(v, "Guest sign in not fully implemented yet", Snackbar.LENGTH_LONG)
+                        .setAction("Action", null)
+                        .show();
+
                 //Show dialog while signing in
-                mConnectionProgressDialog.show();
-                 Intent guestSignInIntent = new Intent(SignInActivity.this, GuestSignInActivity.class);
-                 startActivityForResult(guestSignInIntent, OUR_REQUEST_CODE);
+//                mConnectionProgressDialog.show();
+//                 Intent guestSignInIntent = new Intent(SignInActivity.this, GuestSignInActivity.class);
+//                 startActivityForResult(guestSignInIntent, OUR_REQUEST_CODE);
                 break;
 
             //TODO: the same but with a sign-out button


### PR DESCRIPTION
`handleSignInResult()` in `SignInActivity` now accepts a `Task` object rather than a `SignInResult` object.
Probably due to Google updating their APIs or something.

**We should verify this is working on some machine other than my laptop before merging.**